### PR TITLE
fix: set smartcard library location for linux and fix UI related bugs

### DIFF
--- a/src/main/java/com/truphone/lpap/LPAUI.java
+++ b/src/main/java/com/truphone/lpap/LPAUI.java
@@ -589,7 +589,7 @@ public class LPAUI extends javax.swing.JFrame {
                 try {
                     listProfiles();
                     updateEuiccInfo();
-                } catch (IOException | DecoderException ex) {
+                } catch (Exception ex) {
                     LOG.log(Level.WARNING, ex.toString());
                     DialogHelper.showMessageDialog(null, String.format("Failed to read card info \nReason: %s \nPlease check the log for more info.", ex.getMessage()));
                 }

--- a/src/main/java/com/truphone/lpap/LPAUI.java
+++ b/src/main/java/com/truphone/lpap/LPAUI.java
@@ -589,16 +589,16 @@ public class LPAUI extends javax.swing.JFrame {
                 try {
                     listProfiles();
                     updateEuiccInfo();
+
+                    btnAddProfile.setEnabled(true);
+                    btnSetSMDPAddress.setEnabled(true);
                 } catch (Exception ex) {
                     LOG.log(Level.WARNING, ex.toString());
                     DialogHelper.showMessageDialog(null, String.format("Failed to read card info \nReason: %s \nPlease check the log for more info.", ex.getMessage()));
+                    return null;
+                } finally {
+                    setProcessing(false);
                 }
-
-                setProcessing(false);
-
-                btnAddProfile.setEnabled(true);
-                btnSetSMDPAddress.setEnabled(true);
-
                 return null;
             }
         };
@@ -790,6 +790,7 @@ public class LPAUI extends javax.swing.JFrame {
     private javax.swing.JPopupMenu popUpProfiles;
     private javax.swing.JTextArea txtEuiccInfo;
     // End of variables declaration//GEN-END:variables
+    private HashMap<Component, Boolean> tempStateDisabledComponents = new HashMap<>();
 
     private void initLPA() throws URISyntaxException, Exception {
 
@@ -891,13 +892,18 @@ public class LPAUI extends javax.swing.JFrame {
 //        Thread t = new Thread() {
 //            public void run() {
         lblProgress.setVisible(processing);
-        btnRefreshReaders.setEnabled(!processing);
-        btnConnect.setEnabled(!processing);
-        btnSetSMDPAddress.setEnabled(!processing);
-        btnAddProfile.setEnabled(!processing);
 
-        cmbReaders.setEnabled(!processing);
-        btnHandleNotifications.setEnabled(!processing);
+        final Component[] buttons = Arrays.stream(mainPanel.getComponents()).filter(c -> c instanceof JButton).toArray(Component[]::new);
+        if (processing) {
+            tempStateDisabledComponents = Arrays.stream(buttons).peek(c -> tempStateDisabledComponents.put(c, c.isEnabled())).collect(Collectors.toMap(c -> c, Component::isEnabled, (a, b) -> b, HashMap::new));
+            for (Component component : buttons) {
+                component.setEnabled(false);
+            }
+        } else {
+            for (Component component : buttons) {
+                component.setEnabled(tempStateDisabledComponents.get(component));
+            }
+        }
 
 //      }
 //        };

--- a/src/main/java/com/truphone/lpap/mainUI.java
+++ b/src/main/java/com/truphone/lpap/mainUI.java
@@ -27,15 +27,13 @@ public class mainUI {
      * @param args the command line arguments
      */
     public static void main(String args[]) {
-        
-        System.setProperty("sun.security.smartcardio.library", "/System/Library/Frameworks/PCSC.framework/Versions/Current/PCSC");
-        
-        String loggingConfigFile;
+        String loggingConfigFile = "config/logging.properties";
 
         if (System.getProperty("os.name").toLowerCase().contains("mac")) {
+            System.setProperty("sun.security.smartcardio.library", "/System/Library/Frameworks/PCSC.framework/Versions/Current/PCSC");
             loggingConfigFile = "contents/java/lib/logging.properties";
-        } else {
-            loggingConfigFile = "config/logging.properties";
+        } else if (System.getProperty("os.name").toLowerCase().contains("linux")) {
+            System.setProperty("sun.security.smartcardio.library", "/usr/lib/x86_64-linux-gnu/libpcsclite.so.1");
         }
 
         File propFile = new File(loggingConfigFile);


### PR DESCRIPTION
The location for `libpcsc` on Linux is different from the [hardcoded path in OpenJDK](https://bugs.launchpad.net/ubuntu/+source/openjdk-7/+bug/898689). Since you also customized the path for Macos, this PR would also fix Linux.
- fix: Catch all exceptions to avoid UI freezing
- fix: resets the enabled status after processing